### PR TITLE
Create a sponsorship policy

### DIFF
--- a/sponsorship.html
+++ b/sponsorship.html
@@ -21,7 +21,7 @@ body {
   padding-top: 60px;
 }
 
-p, h1, h2 {
+p, h1, h2, h3, h4, ul, ol {
   max-width: 80%;
   margin-left: auto;
   margin-right: auto;
@@ -34,6 +34,10 @@ h1 {
 h2 {
   font-size: 28px;
   margin-top: 48px;
+}
+
+h3 {
+  font-style: italic;
 }
 
 p {
@@ -90,14 +94,24 @@ em {
 
 <ul>
   <li>Supplying food and drink</li>
-  <li>Paying for a professional speaker</li>
+  <li>Speaking at the meetup</li>
+  <li>Supporting a professional speaker</li>
   <li>Picking up our hosting fees</li>
+  <li>Providing a venue for a special Exchange.js event</li>
   <li>Donating books, licenses or other prizes</li>
 </ul>
 
-<p>We're also open to creative suggestions, so get in touch if you'd like to share your ideas.</p>
+<p>Supplying food and drink is the main way most groups sponsor our meetup, and we need at least one sponsor a month to make this happen. It's a great way to get a special mention at a meetup, as we make sure members know who's supplying the refreshments. Jump ahead to the <a href="#food-and-drink">Food and Drink</a> section for details.</p>
 
-<p>Once you've decided how you'd like to sponsor us fill out the form below and we'll get in touch with more details.<p>
+<p>We're also interested in creative suggestions, so get in touch if you'd like to share your ideas.</p>
+
+<p>Once you've decided how you'd like to sponsor us fill out our sponsorship form and we'll get in touch with more details.</p>
+
+<h2>Food and Drink</h2>
+
+<p>Sponsoring food and drink typically costs between $100-150 per meetup, depending on the number of attendees and the kind of food you choose to provide. Popular food choices are catered sandwiches, wraps, and pizza.</p>
+
+<p>When you decided to sponsor, please fill out our sponsorship form and let us know your preferences. To make sure that all interested sponsors get a chance to participate twice a year, in February and June, we collect the list of sponsors and divide them out between the  interested parties. We then clear the list of waiting sponsors and start again.</p>
 
 <h2>Frequently Asked Questions</h2>
 
@@ -107,13 +121,23 @@ em {
 
 <h3>Why don't you take cash donations?</h3>
 
+<p>We've considered taking cash donations, but doing so would require registering as a not-for-profit and paying for a bank account. We'd rather spend that time and money making the meetup awesome, so ask that all donations are provided in goods and services instead.</p>
+
 <h3>Why do you book sponsorships in advance?</h3>
+
+<p>Booking sponsorship in advance gives us the structure we need to plan out food and other logistics in advance, knowing that we'll be able to cover the costs. By only doing this a few times a year, instead of every month, we can focus on the important tasks of arranging meetups and events.</p>
 
 <h3>Why don't you book sponsorship more than six months in advance?</h3>
 
+<p>Arranging the sponsorship in advance reduces the amount of time we spend chasing down sponsors, but we recognize that planning too far in advance is impractical for some organizations. Six months is a good balance between planning ahead, and not waiting to long for a sponsorship opportunity.</p>
+
 <h3>What kind of options are available for sponsoring the meetup?</h3>
 
-<h3>What if I can't afford to sponsor with goods or services? Are there other ways I can help?</p>
+<p>There are many options available from food and refreshments, to sponsoring speakers and talks.</p>
+
+<h3>What if I can't afford to sponsor with goods or services? Are there other ways I can help?</h3>
+
+<p>Yes! If you'd like to help the meetup but don't have the funds to do so, consider doing a talk or contacting a member of the exec to let them know you're interested.</p>
 
 <div class="footer">
 <p><small><em>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a href="http://geekfeminism.wikia.com/wiki/Meetup_anti-harassment/Policy">The Ada Initiative</a><br>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -64,35 +64,56 @@ em {
 </style>
 </head>
 <body>
-<h1>Meetup Code of Conduct</h1>
+<h1>Meetup Sponsorship</h1>
 
-<p>All attendees, speakers, sponsors and volunteers at our meetup are required to agree with the following code of conduct. Organisers will enforce this code throughout our events. We are expecting cooperation from all participants to help ensuring a safe environment for everybody.</p>
+<p>Enjoy the great food and resources we provide at the JavaScript meetup? As a sponsor of the Edmonton JavaScript meetup there are lots of ways you can help, and benefit. So do the right thing and sponsor us today!</p>
 
-<p><em>tl;dr: Be excellent with each other</em></p>
+<p><em>tl;dr: We book sponsorship up to six months in advance, and take payment in goods and services. No cash, please.</em></p>
 
 <h2>Need Help?</h2>
 
 <p>Contact us on Twitter at <a href="https://twitter.com/edmontonjs">@edmontonjs</a>, or any of <a href="index.html#organizers">the meetup organizers listed on our homepage</a>.</p>
 
-<h2>The Quick Version</h2>
+<h2>Why Sponsor Us</h2>
 
-<p>Our meetup is dedicated to providing a harassment-free meetup experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, or religion (or lack thereof). We do not tolerate harassment of meetup participants in any form. Sexual language and imagery is not appropriate for any meetup venue, including talks, workshops, parties, Twitter and other online media. Meetup participants violating these rules may be sanctioned or expelled from the meetup or event <em>without a refund</em> at the discretion of the meetup organisers.</p>
+<p>Every month The Edmonton JavaScipt Meetup provides a venue, speakers, food and other resources for the local JavaScript community. Beyond this the meetup connects you, the people and organizations that make up the local JavaScript scene, with the successes, stories, and opporunties you care about. Doing all this takes the support of a team of volunteers and a dedicated community of sponsors. We wouldn't exist without you.</p>
 
-<h2>The Less Quick Version</h2>
+<p>There are many benefits to sponsoring the meetup.</p>
 
-<p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+<p>First, your given the opporunity get a special mention at each meetup you sponsor. We do our best to make sure our members know who they have to thank for the meetup each month.</p>
 
-<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+<p>Second, you get a chance to place your companies logo on the homepage of our meetup for the duration of the year you sponsored us. We people don't always make it to every meetup, and we want to show our gratitude for your support all year long.</p>
 
-<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material.</p>
+<h2>How To Sponsor</h2>
 
-<p>If a participant engages in harassing behavior, the meetup organisers may take any action they deem appropriate, including warning the offender or expulsion from the meetup or event with no refund.</p>
+<p>You first need to decide how you'd like to sponsor us. There are many ways to do this such as:</p>
 
-<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please <a href="index.html#organizers">contact a meetup organizer</a> immediately.</p>
+<ul>
+  <li>Supplying food and drink</li>
+  <li>Paying for a professional speaker</li>
+  <li>Picking up our hosting fees</li>
+  <li>Donating books, licenses or other prizes</li>
+</ul>
 
-<p>Meetup organizers will be happy to assist those experiencing harassment to feel safe for the duration of the meetup. We value your attendance.</p>
+<p>We're also open to creative suggestions, so get in touch if you'd like to share your ideas.</p>
 
-<p>We expect participants to follow these rules at meetup and workshop venues and meetup-related social events.</p>
+<p>Once you've decided how you'd like to sponsor us fill out the form below and we'll get in touch with more details.<p>
+
+<h2>Frequently Asked Questions</h2>
+
+<h3>Do I need to sponsor the meetup to share a job opportunity?</h3>
+
+<p>No. Though we encourage you to consider sponsoring the meetup, we welcome all job posting regardless of whether you sponsor or not. That said, if you're finding good people from the meetup, consider sharing the good fortune and giving sponsorship a go.</p>
+
+<h3>Why don't you take cash donations?</h3>
+
+<h3>Why do you book sponsorships in advance?</h3>
+
+<h3>Why don't you book sponsorship more than six months in advance?</h3>
+
+<h3>What kind of options are available for sponsoring the meetup?</h3>
+
+<h3>What if I can't afford to sponsor with goods or services? Are there other ways I can help?</p>
 
 <div class="footer">
 <p><small><em>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a href="http://geekfeminism.wikia.com/wiki/Meetup_anti-harassment/Policy">The Ada Initiative</a><br>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -72,7 +72,7 @@ em {
 
 <p>Enjoy the great food and resources we provide at the JavaScript meetup? As a sponsor of the Edmonton JavaScript meetup there are lots of ways you can help, and benefit. So do the right thing and sponsor us today!</p>
 
-<p><em>tl;dr: We book sponsorship up to six months in advance, and take payment in goods and services. No cash, please.</em></p>
+<p><em>tl;dr: Supplying food and drink is the main way most groups sponsor our meetup, and we need at least one sponsor a month to make this happen. We book sponsorship up to six months in advance, and take payment in goods and services. No cash, please.</em></p>
 
 <h2>Need Help?</h2>
 
@@ -80,11 +80,11 @@ em {
 
 <h2>Why Sponsor Us</h2>
 
-<p>Every month The Edmonton JavaScipt Meetup provides a venue, speakers, food and other resources for the local JavaScript community. Beyond this the meetup connects you, the people and organizations that make up the local JavaScript scene, with the successes, stories, and opporunties you care about. Doing all this takes the support of a team of volunteers and a dedicated community of sponsors. We wouldn't exist without you.</p>
+<p>Every month The Edmonton JavaScipt Meetup provides a venue, speakers, food and other resources for the local JavaScript community. Beyond this the meetup connects you, the people and organizations that make up the local JavaScript scene, with the successes, stories, and opportunities you care about. Doing all this takes the support of a team of volunteers and a dedicated community of sponsors. We wouldn't exist without you.</p>
 
 <p>There are many benefits to sponsoring the meetup.</p>
 
-<p>First, your given the opporunity get a special mention at each meetup you sponsor. We do our best to make sure our members know who they have to thank for the meetup each month.</p>
+<p>First, your given the opportunity to get a special mention at each meetup you sponsor. We do our best to make sure our members know who they have to thank for the meetup each month.</p>
 
 <p>Second, you get a chance to place your companies logo on the homepage of our meetup for the duration of the year you sponsored us. We people don't always make it to every meetup, and we want to show our gratitude for your support all year long.</p>
 

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -1,0 +1,103 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf8">
+<title>Meetup Code of Conduct</title>
+<style>
+* {
+  font-family: 'helvetica neue', arial, helvetica;
+  font-weight: 200;
+}
+
+html {
+  background: #efefef;
+}
+
+body {
+  background: white;
+  color: #212121;
+  margin: 0;
+  padding-top: 60px;
+}
+
+p, h1, h2 {
+  max-width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h1 {
+  font-size: 38px;
+}
+
+h2 {
+  font-size: 28px;
+  margin-top: 48px;
+}
+
+p {
+  line-height: 24px;
+  font-size: 18px;
+  text-align: justify;
+}
+
+a {
+  color: blue;
+}
+
+em {
+  font-weight: 400;
+}
+
+.footer {
+  padding: 40px 0;
+  background: #efefef;
+  margin: 0;
+  margin-top: 40px;
+  max-width: 100%;
+}
+
+.footer p {
+  text-align: left;
+}
+</style>
+</head>
+<body>
+<h1>Meetup Code of Conduct</h1>
+
+<p>All attendees, speakers, sponsors and volunteers at our meetup are required to agree with the following code of conduct. Organisers will enforce this code throughout our events. We are expecting cooperation from all participants to help ensuring a safe environment for everybody.</p>
+
+<p><em>tl;dr: Be excellent with each other</em></p>
+
+<h2>Need Help?</h2>
+
+<p>Contact us on Twitter at <a href="https://twitter.com/edmontonjs">@edmontonjs</a>, or any of <a href="index.html#organizers">the meetup organizers listed on our homepage</a>.</p>
+
+<h2>The Quick Version</h2>
+
+<p>Our meetup is dedicated to providing a harassment-free meetup experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, or religion (or lack thereof). We do not tolerate harassment of meetup participants in any form. Sexual language and imagery is not appropriate for any meetup venue, including talks, workshops, parties, Twitter and other online media. Meetup participants violating these rules may be sanctioned or expelled from the meetup or event <em>without a refund</em> at the discretion of the meetup organisers.</p>
+
+<h2>The Less Quick Version</h2>
+
+<p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+
+<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+
+<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material.</p>
+
+<p>If a participant engages in harassing behavior, the meetup organisers may take any action they deem appropriate, including warning the offender or expulsion from the meetup or event with no refund.</p>
+
+<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please <a href="index.html#organizers">contact a meetup organizer</a> immediately.</p>
+
+<p>Meetup organizers will be happy to assist those experiencing harassment to feel safe for the duration of the meetup. We value your attendance.</p>
+
+<p>We expect participants to follow these rules at meetup and workshop venues and meetup-related social events.</p>
+
+<div class="footer">
+<p><small><em>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a href="http://geekfeminism.wikia.com/wiki/Meetup_anti-harassment/Policy">The Ada Initiative</a><br>
+
+This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a></em></small>
+
+</p>
+</div>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -72,7 +72,7 @@ em {
 
 <p>Enjoy the great food and resources we provide at the JavaScript meetup? As a sponsor of the Edmonton JavaScript meetup there are lots of ways you can help, and benefit. So do the right thing and sponsor us today!</p>
 
-<p><em>tl;dr: Supplying food and drink is the main way most groups sponsor our meetup, and we need at least one sponsor a month to make this happen. We book sponsorship up to six months in advance, and take payment in goods and services. No cash, please.</em></p>
+<p><em>tl;dr: Supplying food and drink is the main way most groups sponsor our meetup, and we need at least one sponsor a month to make this happen. We book sponsorship up to six months in advance, and take payment in goods and services. No cash, please. <a href="https://docs.google.com/forms/d/1oUzwmZ8MFmJjouZUGg4LEkSBiiqUQqO-1CO1lFq_GHI/viewform?usp=send_form">Sponsor us now!</a></em></p>
 
 <h2>Need Help?</h2>
 
@@ -105,13 +105,13 @@ em {
 
 <p>We're also interested in creative suggestions, so get in touch if you'd like to share your ideas.</p>
 
-<p>Once you've decided how you'd like to sponsor us fill out our sponsorship form and we'll get in touch with more details.</p>
+<p>Once you've decided how you'd like to sponsor us <a href="https://docs.google.com/forms/d/1oUzwmZ8MFmJjouZUGg4LEkSBiiqUQqO-1CO1lFq_GHI/viewform?usp=send_form">fill out our sponsorship form</a> and we'll get in touch with more details.</p>
 
 <h2>Food and Drink</h2>
 
 <p>Sponsoring food and drink typically costs between $100-150 per meetup, depending on the number of attendees and the kind of food you choose to provide. Popular food choices are catered sandwiches, wraps, and pizza.</p>
 
-<p>When you decided to sponsor, please fill out our sponsorship form and let us know your preferences. To make sure that all interested sponsors get a chance to participate twice a year, in February and June, we collect the list of sponsors and divide them out between the  interested parties. We then clear the list of waiting sponsors and start again.</p>
+<p>When you decided to sponsor, please <a href="https://docs.google.com/forms/d/1oUzwmZ8MFmJjouZUGg4LEkSBiiqUQqO-1CO1lFq_GHI/viewform?usp=send_form">fill out our sponsorship form</a> and let us know your preferences. To make sure that all interested sponsors get a chance to participate twice a year, in February and June, we collect the list of sponsors and divide them out between the  interested parties. We then clear the list of waiting sponsors and start again.</p>
 
 <h2>Frequently Asked Questions</h2>
 


### PR DESCRIPTION
This is a placeholder for work on our sponsorship policy. Once we've agreed on what it is I'll update the HTML and we can merge it in.

The objectives of the sponsorship policy are:

1) Sustain the meetup
2) Reduce month-to-month administration of sponsorship
3) Share and grow the JavaScript community in Edmonton
# To Do
- [x] Create form to let sponsors sign up
- [x] Proof read
- [x] Add sponsorship announcement to May notes
