### PR TITLE
Update with link to slides and canonical title

### DIFF
--- a/events/apr-2016/index.html
+++ b/events/apr-2016/index.html
@@ -193,7 +193,7 @@
           </section>
           <section class="headshot">
             <img src="../imgs/Eddie-Santos.jpg" alt="Eddie Santos">
-            <h1>Introduction to Object.prototype</h1>
+            <h1><a href="http://www.eddieantonio.ca/ExchangeJS-Prototypes/#/">Prototypes: A Beginner's Guide</a></h1>
             <h2>by <a href="https://twitter.com/_eddieantonio">Eddie Santos</a></h2>
           </section>
           <section class="headshot">


### PR DESCRIPTION
Added a link to my actual slides (http://www.eddieantonio.ca/ExchangeJS-Prototypes/ or https://github.com/eddieantonio/ExchangeJS-Prototypes) and used the title I use in the presentation.
